### PR TITLE
feat: added frontmatter escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ Meanings of parameters:
     * `pre_blocks`—pre code blocks;
     * `inline_code`—inline code;
     * `comments`—HTML-style comments, also usual for Markdown;
-    * `tags`—content of certain tags with the tags themselves, for example `plantuml` for `<plantuml>...</plantuml>`.
+    * `tags`—content of certain tags with the tags themselves, for example `plantuml` for `<plantuml>...</plantuml>`;
+    * `frontmater`—the part with metadata at the beginning of the Markdown file, supports YAML `---` and TOML `+++` formats.
 * `pattern_override`—a regular expression that will not be escaped:
     * `pre_blocks`—the lines of the pre code block containing this template will not be escaped;
     * `inline_code`—pattern for inline code;

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Meanings of parameters:
     * `inline_code`—inline code;
     * `comments`—HTML-style comments, also usual for Markdown;
     * `tags`—content of certain tags with the tags themselves, for example `plantuml` for `<plantuml>...</plantuml>`;
-    * `frontmater`—the part with metadata at the beginning of the Markdown file, supports YAML `---` and TOML `+++` formats.
+    * `frontmatter`—the part with metadata at the beginning of the Markdown file, supports YAML `---` and TOML `+++` formats.
 * `pattern_override`—a regular expression that will not be escaped:
     * `pre_blocks`—the lines of the pre code block containing this template will not be escaped;
     * `inline_code`—pattern for inline code;

--- a/foliant/preprocessors/escapecode.py
+++ b/foliant/preprocessors/escapecode.py
@@ -266,7 +266,6 @@ class Preprocessor(BasePreprocessor):
                     if type(action) == dict:
                         for escape_action in action['escape']:
                             if escape_action == 'frontmatter':
-                                print(escape_action)
                                 frontmatter = self.escape_for_raw_type(frontmatter, 'fence_blocks')
                 markdown_content = f"{format}\n" + frontmatter + f"\n{format}\n" + self.escape(content)
             else:

--- a/foliant/preprocessors/escapecode.py
+++ b/foliant/preprocessors/escapecode.py
@@ -257,9 +257,13 @@ class Preprocessor(BasePreprocessor):
                     return m.group(2)
                 def _sub_content(m):
                     return m.group(4)
+                def _sub_format(m):
+                    return m.group(1)
                 frontmatter = self.frontmatter_pattern.sub(_sub_frontmatter, markdown_content)
                 content = self.frontmatter_pattern.sub(_sub_content, markdown_content)
-                markdown_content = '---\n' + self.escape_for_raw_type(frontmatter, 'fence_blocks') + '\n---' + self.escape(content)
+                format = self.frontmatter_pattern.sub(_sub_format, markdown_content)
+                markdown_content = f"{format}\n" + self.escape_for_raw_type(frontmatter, 'fence_blocks') + f"\n{format}" + self.escape(content)
+                print(markdown_content)
             else:
                 markdown_content = self.escape(markdown_content)
 

--- a/tests/data/expected/frontmatter_toml.md
+++ b/tests/data/expected/frontmatter_toml.md
@@ -1,0 +1,12 @@
++++
+<escaped hash="b376c6b51a65a2cb25a6fc3c7868a90e"></escaped>
++++
+
+# Test
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/data/expected/frontmatter_yaml.md
+++ b/tests/data/expected/frontmatter_yaml.md
@@ -1,0 +1,12 @@
+---
+<escaped hash="6c2f9a3afcbab2e7eb03f6f292e18185"></escaped>
+---
+
+# Test
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/data/input/frontmatter_toml.md
+++ b/tests/data/input/frontmatter_toml.md
@@ -1,0 +1,14 @@
++++
+pre = "<i class='fas fa-share-square'></i>"
+description = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore."
++++
+
+# Test
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/data/input/frontmatter_yaml.md
+++ b/tests/data/input/frontmatter_yaml.md
@@ -1,0 +1,14 @@
+---
+pre: "<i class='fas fa-share-square'></i>"
+description: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore."
+---
+
+# Test
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/test_escapecode.py
+++ b/tests/test_escapecode.py
@@ -25,7 +25,8 @@ class TestEscapecode(TestCase):
                         'fence_blocks',
                         'pre_blocks',
                         'inline_code',
-                        'comments'
+                        'comments',
+                        'frontmatter',
                     ]
                 }
             ],
@@ -144,6 +145,30 @@ class TestEscapecode(TestCase):
         }
         content = data_file_content(os.path.join('data', 'input', 'pattern_override.md'))
         content_with_hash = data_file_content(os.path.join('data', 'expected', 'pattern_override.md'))
+        self.ptf.test_preprocessor(
+            input_mapping = {
+                'index.md': content
+            },
+            expected_mapping = {
+                'index.md': content_with_hash
+            }
+        )
+
+    def test_frontmatter(self):
+        content = data_file_content(os.path.join('data', 'input', 'frontmatter_yaml.md'))
+        content_with_hash = data_file_content(os.path.join('data', 'expected', 'frontmatter_yaml.md'))
+        self.ptf.test_preprocessor(
+            input_mapping = {
+                'index.md': content
+            },
+            expected_mapping = {
+                'index.md': content_with_hash
+            }
+        )
+
+    def test_frontmatter(self):
+        content = data_file_content(os.path.join('data', 'input', 'frontmatter_toml.md'))
+        content_with_hash = data_file_content(os.path.join('data', 'expected', 'frontmatter_toml.md'))
         self.ptf.test_preprocessor(
             input_mapping = {
                 'index.md': content

--- a/tests/test_escapecode.py
+++ b/tests/test_escapecode.py
@@ -154,7 +154,7 @@ class TestEscapecode(TestCase):
             }
         )
 
-    def test_frontmatter(self):
+    def test_frontmatter_yaml(self):
         content = data_file_content(os.path.join('data', 'input', 'frontmatter_yaml.md'))
         content_with_hash = data_file_content(os.path.join('data', 'expected', 'frontmatter_yaml.md'))
         self.ptf.test_preprocessor(
@@ -166,7 +166,7 @@ class TestEscapecode(TestCase):
             }
         )
 
-    def test_frontmatter(self):
+    def test_frontmatter_toml(self):
         content = data_file_content(os.path.join('data', 'input', 'frontmatter_toml.md'))
         content_with_hash = data_file_content(os.path.join('data', 'expected', 'frontmatter_toml.md'))
         self.ptf.test_preprocessor(

--- a/tests/test_unescapecode.py
+++ b/tests/test_unescapecode.py
@@ -106,7 +106,7 @@ class TestUnescapecode(TestCase):
             }
         )
 
-    def test_frontmatter(self):
+    def test_frontmatter_yaml(self):
         content = data_file_content(os.path.join('data', 'expected', 'frontmatter_yaml.md'))
         content_with_hash = data_file_content(os.path.join('data', 'input', 'frontmatter_yaml.md'))
         self.ptf.test_preprocessor(
@@ -118,7 +118,7 @@ class TestUnescapecode(TestCase):
             }
         )
 
-    def test_frontmatter(self):
+    def test_frontmatter_toml(self):
         content = data_file_content(os.path.join('data', 'expected', 'frontmatter_toml.md'))
         content_with_hash = data_file_content(os.path.join('data', 'input', 'frontmatter_toml.md'))
         self.ptf.test_preprocessor(

--- a/tests/test_unescapecode.py
+++ b/tests/test_unescapecode.py
@@ -105,3 +105,27 @@ class TestUnescapecode(TestCase):
                 'index.md': content_with_hash
             }
         )
+
+    def test_frontmatter(self):
+        content = data_file_content(os.path.join('data', 'expected', 'frontmatter_yaml.md'))
+        content_with_hash = data_file_content(os.path.join('data', 'input', 'frontmatter_yaml.md'))
+        self.ptf.test_preprocessor(
+            input_mapping = {
+                'index.md': content
+            },
+            expected_mapping = {
+                'index.md': content_with_hash
+            }
+        )
+
+    def test_frontmatter(self):
+        content = data_file_content(os.path.join('data', 'expected', 'frontmatter_toml.md'))
+        content_with_hash = data_file_content(os.path.join('data', 'input', 'frontmatter_toml.md'))
+        self.ptf.test_preprocessor(
+            input_mapping = {
+                'index.md': content
+            },
+            expected_mapping = {
+                'index.md': content_with_hash
+            }
+        )


### PR DESCRIPTION
Added frontmatter escaping and fixed incorrect operation of escape code with files having frontmatter.

- frontmatter is escaped in a single tag,
- supported formats: TOML `+++` and YAML `---`.

- [x] add a test